### PR TITLE
Syntax cleanup and random target selection.

### DIFF
--- a/ping_russia.sh
+++ b/ping_russia.sh
@@ -13,6 +13,7 @@
 LOG_FILE="./frwl.$(date +%Y-%m-%d).log" #log file(use /dev/null if u dont want logging)
 ITER=0
 PROBES=$1
+SERVERS=./servers.txt
 COMP_ITER=0
 WORKING_DIR="./working_dir" #directory for uncompressed raw data
 TARBALL_DIR="./from_russia_with_love_comp" #directory for compressed tarballs
@@ -73,7 +74,7 @@ fi
 
 while true
 do
-  for SERVER in $(grep -v /usr/bin/sort -R ./servers.text | head -${PROBES}); do
+  for SERVER in $(grep -v '^#' ${SERVERS} | grep -v '^$' | /usr/bin/sort -R | head -${PROBES}); do
     TIME=$(date +%s)
     SIZE=$(du -B 50M "${WORKING_DIR}" | cut -d "	" -f 1)
     traceroute -n -I ${SERVER} > "${WORKING_DIR}/${ITER}.${TIME}.old"


### PR DESCRIPTION
See commit message, but the result of the usage of 'sort -R' is:

$ grep -v '^#'  servers.txt  | grep -v '^$' | /usr/bin/sort -R | head -5
194.85.40.38
195.239.3.113
195.239.6.8
84.201.133.122
84.242.47.247

$ grep -v '^#'  servers.txt  | grep -v '^$' | /usr/bin/sort -R | head -5
91.204.129.117
193.203.102.97
195.16.54.49
195.62.52.8
212.57.113.89

$ grep -v '^#'  servers.txt  | grep -v '^$' | /usr/bin/sort -R | head -5
194.85.119.68
80.76.244.241
85.192.165.87
37.29.116.243
77.41.147.144


$ grep -v '^#'  servers.txt  | grep -v '^$' | /usr/bin/sort -R | head -5
37.29.107.1
84.253.119.85
79.134.214.149
176.32.33.159
80.66.157.253
