### PR TITLE
Use bash's command function instead of which

### DIFF
--- a/ping_russia.sh
+++ b/ping_russia.sh
@@ -72,7 +72,7 @@ _log date "${TIMEZONE}"
 _log date "[main]script start"
 
 for p in "${DEPENDENCIES[@]}"; do
-    if ! [ -x "$(which $p)" ]; then
+    if ! [ -x "$(command -v $p)" ]; then
         echo "$p is not installed or in the scripts PATH"; exit 1;
     fi
 done


### PR DESCRIPTION
I may be nitpicking here, but not all systems have `which` and it's better practice to use `command` as it's built-in to the bash shell (which we assume to be using according to the shebang).

Looks like someone changed it to `which` after my PR #8 